### PR TITLE
Feature: skip digital music silence based on RMS analysis (based on LibVLCSharp)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,7 @@
 - When behavior is unclear, check live Spice86 state first if available. Spice86 now exposes MCP tooling and runtime inspection surfaces; use that, the debugger/GDB flow, or dump artifacts before inventing logic. Reference: https://github.com/OpenRakis/Spice86/blob/master/doc/mcp.md
 - Use current repository evidence as the source of truth: `dump/spice86dumpExecutionFlow.json`, `dump/spice86dumpGhidraSymbols.txt`, `dump/CodeGeneratorConfig.json`, generated globals, and any targeted memory dumps captured by the project.
 - Preserve observed game behavior, including quirks, unless you have strong runtime evidence that the current behavior is wrong.
+- No new fallback behavior from Copilot: do not invent or add new silent fallback paths or degraded alternate implementations. Existing fallback behavior already present in the repository is allowed and should be preserved unless explicitly requested to change. If required evidence or functionality is missing, fail fast with explicit logging instead of masking the issue.
 - Link to existing docs instead of restating them. Use `README.md` for architecture and run commands, and `CONTRIBUTING.md` for override workflow and coding examples.
 - When approaching an architectural question (what functions share state, which data structures cross file boundaries, how a driver subsystem is structured), query the knowledge graph before grepping raw files. See the **Knowledge Graph** section below.
 

--- a/src/Cryogenic/Services/MusicFolderPlayer.cs
+++ b/src/Cryogenic/Services/MusicFolderPlayer.cs
@@ -5,6 +5,7 @@ using LibVLCSharp.Shared;
 using Serilog;
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -46,7 +47,7 @@ public sealed class MusicFolderPlayer : IDisposable {
 	private readonly StartupTrackSilenceAnalyzer _silenceAnalyzer;
 	private readonly Dictionary<string, FingerprintEntry> _registry;
 	private readonly Dictionary<string, ResolvedTrack> _resolvedTracks;
-	private readonly Dictionary<string, TrackAnalysisCacheEntry> _analysisByFingerprint;
+	private readonly ConcurrentDictionary<string, TrackAnalysisCacheEntry> _analysisByFingerprint;
 	private float _volume = 1.0f;
 	private long _currentTrackSkipMs;
 	/// <summary>
@@ -89,10 +90,10 @@ public sealed class MusicFolderPlayer : IDisposable {
 	/// </param>
 	public MusicFolderPlayer(string folderPath) {
 		_folderPath = folderPath;
-		_analysisCachePath = Path.Combine(_folderPath, AnalysisCacheFileName);
+		_analysisCachePath = Path.Join(_folderPath, AnalysisCacheFileName);
 		_registry = new Dictionary<string, FingerprintEntry>(StringComparer.Ordinal);
 		_resolvedTracks = new Dictionary<string, ResolvedTrack>(StringComparer.Ordinal);
-		_analysisByFingerprint = new Dictionary<string, TrackAnalysisCacheEntry>(StringComparer.Ordinal);
+		_analysisByFingerprint = new ConcurrentDictionary<string, TrackAnalysisCacheEntry>(StringComparer.Ordinal);
 		Core.Initialize();
 		_libVlc = new LibVLC();
 		_mediaPlayer = new MediaPlayer(_libVlc);
@@ -145,7 +146,8 @@ public sealed class MusicFolderPlayer : IDisposable {
 		_mediaPlayer.Media = media;
 		bool started = _mediaPlayer.Play();
 		if (!started) {
-			throw new InvalidOperationException($"LibVLC could not open '{resolvedTrack.FilePath}'.");
+			PlayerLogger.Warning("LibVLC could not open replacement track '{FilePath}' for fingerprint {Fingerprint}. Falling through to MT-32.", resolvedTrack.FilePath, fingerprint);
+			return;
 		}
 
 		ApplyTrackSkip(analysisEntry.SkipMs, resolvedTrack.FilePath, fingerprint);
@@ -185,12 +187,15 @@ public sealed class MusicFolderPlayer : IDisposable {
 			_mediaPlayer.Stop();
 			bool restarted = _mediaPlayer.Play();
 			if (!restarted) {
-				throw new InvalidOperationException("Loop restart failed in MediaPlayer.");
+				PlayerLogger.Warning("Loop restart failed in MediaPlayer for fingerprint {Fingerprint}.", _currentFingerprint);
+				Stop();
+				return;
 			}
 			if (_currentTrackSkipMs > 0) {
 				Media? media = _mediaPlayer.Media;
 				if (media is null) {
-					throw new InvalidOperationException("Loop restart media context is missing.");
+					PlayerLogger.Warning("Loop restart media context is missing for fingerprint {Fingerprint}.", _currentFingerprint);
+					return;
 				}
 				ApplyTrackSkip(_currentTrackSkipMs, media.Mrl, _currentFingerprint);
 			}
@@ -246,7 +251,6 @@ public sealed class MusicFolderPlayer : IDisposable {
 		Stopwatch stopwatch = Stopwatch.StartNew();
 		int cacheHits = 0;
 		int analyzedCount = 0;
-		Lock sync = new Lock();
 		ParallelOptions options = new ParallelOptions { MaxDegreeOfParallelism = Math.Min(Environment.ProcessorCount, 4) };
 
 		Parallel.ForEach(_resolvedTracks, options, pair => {
@@ -254,9 +258,7 @@ public sealed class MusicFolderPlayer : IDisposable {
 			ResolvedTrack resolvedTrack = pair.Value;
 
 			if (TryGetFreshCachedEntry(fingerprint, resolvedTrack, out TrackAnalysisCacheEntry cachedEntry)) {
-				lock (sync) {
-					_analysisByFingerprint[fingerprint] = cachedEntry;
-				}
+				_analysisByFingerprint[fingerprint] = cachedEntry;
 				Interlocked.Increment(ref cacheHits);
 				return;
 			}
@@ -272,21 +274,18 @@ public sealed class MusicFolderPlayer : IDisposable {
 					resolvedTrack.FilePath,
 					resolvedTrack.FileSize,
 					resolvedTrack.LastWriteUtcTicks);
-			} catch (Exception ex) {
+			} catch (InvalidOperationException ex) {
 				PlayerLogger.Warning(ex, "Track analysis failed for fingerprint {Fingerprint}. Using zero skip.", fingerprint);
-				newEntry = TrackAnalysisCacheEntry.Create(
-					fingerprint,
-					0,
-					0.0,
-					CurrentAnalysisVersion,
-					resolvedTrack.FilePath,
-					resolvedTrack.FileSize,
-					resolvedTrack.LastWriteUtcTicks);
+				newEntry = CreateZeroSkipEntry(fingerprint, resolvedTrack);
+			} catch (IOException ex) {
+				PlayerLogger.Warning(ex, "Track analysis failed for fingerprint {Fingerprint}. Using zero skip.", fingerprint);
+				newEntry = CreateZeroSkipEntry(fingerprint, resolvedTrack);
+			} catch (UnauthorizedAccessException ex) {
+				PlayerLogger.Warning(ex, "Track analysis failed for fingerprint {Fingerprint}. Using zero skip.", fingerprint);
+				newEntry = CreateZeroSkipEntry(fingerprint, resolvedTrack);
 			}
 
-			lock (sync) {
-				_analysisByFingerprint[fingerprint] = newEntry;
-			}
+			_analysisByFingerprint[fingerprint] = newEntry;
 			Interlocked.Increment(ref analyzedCount);
 		});
 
@@ -297,6 +296,17 @@ public sealed class MusicFolderPlayer : IDisposable {
 			cacheHits,
 			analyzedCount,
 			stopwatch.ElapsedMilliseconds);
+	}
+
+	private static TrackAnalysisCacheEntry CreateZeroSkipEntry(string fingerprint, in ResolvedTrack resolvedTrack) {
+		return TrackAnalysisCacheEntry.Create(
+			fingerprint,
+			0,
+			0.0,
+			CurrentAnalysisVersion,
+			resolvedTrack.FilePath,
+			resolvedTrack.FileSize,
+			resolvedTrack.LastWriteUtcTicks);
 	}
 
 	private bool TryGetFreshCachedEntry(string fingerprint, in ResolvedTrack resolvedTrack, out TrackAnalysisCacheEntry entry) {
@@ -324,7 +334,19 @@ public sealed class MusicFolderPlayer : IDisposable {
 		try {
 			string json = File.ReadAllText(_analysisCachePath);
 			container = JsonSerializer.Deserialize<TrackAnalysisCacheContainer>(json);
-		} catch (Exception ex) {
+		} catch (IOException ex) {
+			PlayerLogger.Warning(ex, "Could not read analysis cache '{Path}'. Rebuilding cache.", _analysisCachePath);
+			_analysisByFingerprint.Clear();
+			return;
+		} catch (UnauthorizedAccessException ex) {
+			PlayerLogger.Warning(ex, "Could not read analysis cache '{Path}'. Rebuilding cache.", _analysisCachePath);
+			_analysisByFingerprint.Clear();
+			return;
+		} catch (JsonException ex) {
+			PlayerLogger.Warning(ex, "Could not read analysis cache '{Path}'. Rebuilding cache.", _analysisCachePath);
+			_analysisByFingerprint.Clear();
+			return;
+		} catch (NotSupportedException ex) {
 			PlayerLogger.Warning(ex, "Could not read analysis cache '{Path}'. Rebuilding cache.", _analysisCachePath);
 			_analysisByFingerprint.Clear();
 			return;
@@ -351,10 +373,17 @@ public sealed class MusicFolderPlayer : IDisposable {
 	}
 
 	private static Dictionary<string, string> BuildFileNameLookup(string folderPath) {
-		return Directory
-			.GetFiles(folderPath)
-			.Where(path => !string.IsNullOrEmpty(Path.GetFileName(path)))
-			.ToDictionary(path => Path.GetFileName(path).ToLowerInvariant(), path => path, StringComparer.OrdinalIgnoreCase);
+		Dictionary<string, string> filesByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		foreach (string path in Directory.GetFiles(folderPath).OrderBy(path => path, StringComparer.Ordinal)) {
+			string fileName = Path.GetFileName(path);
+			if (string.IsNullOrEmpty(fileName)) {
+				continue;
+			}
+			if (!filesByName.TryAdd(fileName, path)) {
+				PlayerLogger.Warning("Duplicate replacement filename ignored. FileName='{FileName}' Kept='{Kept}' Ignored='{Ignored}'", fileName, filesByName[fileName], path);
+			}
+		}
+		return filesByName;
 	}
 
 	private void ApplyTrackSkip(long skipMs, string filePath, string fingerprint) {
@@ -371,7 +400,8 @@ public sealed class MusicFolderPlayer : IDisposable {
 		}
 
 		if (!_mediaPlayer.IsSeekable || _mediaPlayer.Length <= 0) {
-			throw new InvalidOperationException($"Track '{filePath}' is not seekable for fingerprint '{fingerprint}'.");
+			PlayerLogger.Warning("Track '{FilePath}' is not seekable for fingerprint {Fingerprint}. Keeping position at track start.", filePath, fingerprint);
+			return;
 		}
 
 		long clampedSkipMs = Math.Min(skipMs, Math.Max(0, _mediaPlayer.Length - 1));
@@ -380,7 +410,7 @@ public sealed class MusicFolderPlayer : IDisposable {
 	}
 
 	private void LoadRegistry() {
-		string registryPath = Path.Combine(_folderPath, "fingerprints.json");
+		string registryPath = Path.Join(_folderPath, "fingerprints.json");
 		if (!File.Exists(registryPath)) {
 			throw new FileNotFoundException($"fingerprints.json not found at '{registryPath}'.", registryPath);
 		}

--- a/src/Cryogenic/Services/MusicFolderPlayer.cs
+++ b/src/Cryogenic/Services/MusicFolderPlayer.cs
@@ -367,7 +367,7 @@ public sealed class MusicFolderPlayer : IDisposable {
 			if (_mediaPlayer.IsSeekable && _mediaPlayer.Length > 0) {
 				break;
 			}
-			Thread.Sleep(10);
+			Thread.Yield();
 		}
 
 		if (!_mediaPlayer.IsSeekable || _mediaPlayer.Length <= 0) {

--- a/src/Cryogenic/Services/MusicFolderPlayer.cs
+++ b/src/Cryogenic/Services/MusicFolderPlayer.cs
@@ -6,10 +6,14 @@ using Serilog;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
+using System.Threading.Tasks;
 
 /// <summary>
 /// Plays audio files from a configured local folder as replacements for the game's native MT-32 music.
@@ -32,12 +36,19 @@ using System.Threading;
 public sealed class MusicFolderPlayer : IDisposable {
 	private static readonly ILogger PlayerLogger = Log.ForContext("Subsystem", "MusicFolderPlayer");
 	private static readonly string[] AudioExtensions = ["mp3", "ogg", "wav", "flac", "aac"];
+	private const string AnalysisCacheFileName = "track-analysis-cache.json";
+	private const int CurrentAnalysisVersion = 1;
 
 	private readonly string _folderPath;
+	private readonly string _analysisCachePath;
 	private readonly LibVLC _libVlc;
 	private readonly MediaPlayer _mediaPlayer;
+	private readonly StartupTrackSilenceAnalyzer _silenceAnalyzer;
 	private readonly Dictionary<string, FingerprintEntry> _registry;
+	private readonly Dictionary<string, ResolvedTrack> _resolvedTracks;
+	private readonly Dictionary<string, TrackAnalysisCacheEntry> _analysisByFingerprint;
 	private float _volume = 1.0f;
+	private long _currentTrackSkipMs;
 	/// <summary>
 	/// Fingerprint of the song currently loaded in the media player, or empty when none.
 	/// Used to avoid stopping and restarting LibVLC when the game re-opens the same song
@@ -78,12 +89,17 @@ public sealed class MusicFolderPlayer : IDisposable {
 	/// </param>
 	public MusicFolderPlayer(string folderPath) {
 		_folderPath = folderPath;
+		_analysisCachePath = Path.Combine(_folderPath, AnalysisCacheFileName);
 		_registry = new Dictionary<string, FingerprintEntry>(StringComparer.Ordinal);
+		_resolvedTracks = new Dictionary<string, ResolvedTrack>(StringComparer.Ordinal);
+		_analysisByFingerprint = new Dictionary<string, TrackAnalysisCacheEntry>(StringComparer.Ordinal);
 		Core.Initialize();
 		_libVlc = new LibVLC();
 		_mediaPlayer = new MediaPlayer(_libVlc);
+		_silenceAnalyzer = new StartupTrackSilenceAnalyzer(_libVlc);
 		_mediaPlayer.EndReached += OnEndReached;
 		LoadRegistry();
+		InitializeTrackCatalogAndAnalysis();
 	}
 
 	/// <summary>
@@ -116,29 +132,26 @@ public sealed class MusicFolderPlayer : IDisposable {
 			Stop();
 		}
 
-		IReadOnlyList<string> songNames = _registry.TryGetValue(fingerprint, out FingerprintEntry? entry) ? entry.Names : [];
-		string resolvedPath = ResolveFilePath(songNames);
-		if (string.IsNullOrEmpty(resolvedPath)) {
-			PlayerLogger.Warning("No replacement file for song {Fingerprint} (names='{Names}'). Falling through to MT-32.", fingerprint, string.Join(", ", songNames));
+		if (!_resolvedTracks.TryGetValue(fingerprint, out ResolvedTrack resolvedTrack)) {
+			IReadOnlyList<string> songNames = _registry.TryGetValue(fingerprint, out FingerprintEntry? entry) ? entry.Names : [];
+			PlayerLogger.Debug("No replacement file for fingerprint {Fingerprint} (names='{Names}'). Falling through to MT-32.", fingerprint, string.Join(", ", songNames));
 			return;
 		}
-
-		try {
-			Media media = new Media(_libVlc, resolvedPath, FromType.FromPath);
-			_mediaPlayer.Media = media;
-			media.Dispose();
-			bool started = _mediaPlayer.Play();
-			if (!started) {
-				PlayerLogger.Warning("LibVLC could not open '{FilePath}'. Falling through to MT-32.", resolvedPath);
-				IsActive = false;
-				return;
-			}
-			IsActive = true;
-			_currentFingerprint = fingerprint;
-		} catch (Exception ex) {
-			PlayerLogger.Warning(ex, "LibVLC could not open '{FilePath}'. Falling through to MT-32.", resolvedPath);
-			IsActive = false;
+		if (!_analysisByFingerprint.TryGetValue(fingerprint, out TrackAnalysisCacheEntry analysisEntry)) {
+			analysisEntry = TrackAnalysisCacheEntry.Create(fingerprint, 0, 0.0, CurrentAnalysisVersion, resolvedTrack.FilePath, resolvedTrack.FileSize, resolvedTrack.LastWriteUtcTicks);
 		}
+
+		using Media media = new Media(_libVlc, resolvedTrack.FilePath, FromType.FromPath);
+		_mediaPlayer.Media = media;
+		bool started = _mediaPlayer.Play();
+		if (!started) {
+			throw new InvalidOperationException($"LibVLC could not open '{resolvedTrack.FilePath}'.");
+		}
+
+		ApplyTrackSkip(analysisEntry.SkipMs, resolvedTrack.FilePath, fingerprint);
+		IsActive = true;
+		_currentFingerprint = fingerprint;
+		_currentTrackSkipMs = analysisEntry.SkipMs;
 	}
 
 	/// <summary>
@@ -149,6 +162,7 @@ public sealed class MusicFolderPlayer : IDisposable {
 		_mediaPlayer.Stop();
 		IsActive = false;
 		_currentFingerprint = string.Empty;
+		_currentTrackSkipMs = 0;
 	}
 
 	/// <inheritdoc />
@@ -169,37 +183,206 @@ public sealed class MusicFolderPlayer : IDisposable {
 				return;
 			}
 			_mediaPlayer.Stop();
-			_mediaPlayer.Play();
+			bool restarted = _mediaPlayer.Play();
+			if (!restarted) {
+				throw new InvalidOperationException("Loop restart failed in MediaPlayer.");
+			}
+			if (_currentTrackSkipMs > 0) {
+				Media? media = _mediaPlayer.Media;
+				if (media is null) {
+					throw new InvalidOperationException("Loop restart media context is missing.");
+				}
+				ApplyTrackSkip(_currentTrackSkipMs, media.Mrl, _currentFingerprint);
+			}
 		});
 	}
 
-	private string ResolveFilePath(IReadOnlyList<string> songNames) {
+	private static string ResolveFilePath(IReadOnlyList<string> songNames, IReadOnlyDictionary<string, string> filesByName) {
 		if (songNames.Count == 0) {
 			return string.Empty;
 		}
-		string[] filesInFolder = Directory.Exists(_folderPath)
-			? Directory.GetFiles(_folderPath)
-			: [];
 		foreach (string songName in songNames) {
 			if (string.IsNullOrWhiteSpace(songName)) {
 				continue;
 			}
-			string? match = AudioExtensions
-				.Select(ext => filesInFolder.FirstOrDefault(
-					f => string.Equals(Path.GetFileName(f), $"{songName}.{ext}", StringComparison.OrdinalIgnoreCase)))
-				.FirstOrDefault(m => m is not null);
-			if (match is not null) {
-				return match;
+			foreach (string extension in AudioExtensions) {
+				string key = $"{songName}.{extension}".ToLowerInvariant();
+				if (filesByName.TryGetValue(key, out string? path) && !string.IsNullOrEmpty(path)) {
+					return path;
+				}
 			}
 		}
 		return string.Empty;
 	}
 
+	private void InitializeTrackCatalogAndAnalysis() {
+		if (!Directory.Exists(_folderPath)) {
+			throw new DirectoryNotFoundException($"Music folder '{_folderPath}' does not exist.");
+		}
+
+		Dictionary<string, string> filesByName = BuildFileNameLookup(_folderPath);
+		foreach (KeyValuePair<string, FingerprintEntry> pair in _registry) {
+			string fingerprint = pair.Key;
+			string resolvedPath = ResolveFilePath(pair.Value.Names, filesByName);
+			if (string.IsNullOrEmpty(resolvedPath)) {
+				continue;
+			}
+
+			FileInfo fileInfo = new FileInfo(resolvedPath);
+			if (!fileInfo.Exists) {
+				throw new FileNotFoundException($"Resolved replacement file does not exist for '{fingerprint}'.", resolvedPath);
+			}
+
+			ResolvedTrack resolvedTrack = new ResolvedTrack(resolvedPath, fileInfo.Length, fileInfo.LastWriteTimeUtc.Ticks);
+			_resolvedTracks[fingerprint] = resolvedTrack;
+		}
+
+		LoadAnalysisCache();
+		AnalyzeTracksAtStartup();
+		SaveAnalysisCache();
+	}
+
+	private void AnalyzeTracksAtStartup() {
+		Stopwatch stopwatch = Stopwatch.StartNew();
+		int cacheHits = 0;
+		int analyzedCount = 0;
+		Lock sync = new Lock();
+		ParallelOptions options = new ParallelOptions { MaxDegreeOfParallelism = Math.Min(Environment.ProcessorCount, 4) };
+
+		Parallel.ForEach(_resolvedTracks, options, pair => {
+			string fingerprint = pair.Key;
+			ResolvedTrack resolvedTrack = pair.Value;
+
+			if (TryGetFreshCachedEntry(fingerprint, resolvedTrack, out TrackAnalysisCacheEntry cachedEntry)) {
+				lock (sync) {
+					_analysisByFingerprint[fingerprint] = cachedEntry;
+				}
+				Interlocked.Increment(ref cacheHits);
+				return;
+			}
+
+			TrackAnalysisCacheEntry newEntry;
+			try {
+				TrackSilenceAnalysisResult result = _silenceAnalyzer.Analyze(resolvedTrack.FilePath);
+				newEntry = TrackAnalysisCacheEntry.Create(
+					fingerprint,
+					result.SkipMs,
+					result.Confidence,
+					CurrentAnalysisVersion,
+					resolvedTrack.FilePath,
+					resolvedTrack.FileSize,
+					resolvedTrack.LastWriteUtcTicks);
+			} catch (Exception ex) {
+				PlayerLogger.Warning(ex, "Track analysis failed for fingerprint {Fingerprint}. Using zero skip.", fingerprint);
+				newEntry = TrackAnalysisCacheEntry.Create(
+					fingerprint,
+					0,
+					0.0,
+					CurrentAnalysisVersion,
+					resolvedTrack.FilePath,
+					resolvedTrack.FileSize,
+					resolvedTrack.LastWriteUtcTicks);
+			}
+
+			lock (sync) {
+				_analysisByFingerprint[fingerprint] = newEntry;
+			}
+			Interlocked.Increment(ref analyzedCount);
+		});
+
+		stopwatch.Stop();
+		PlayerLogger.Information(
+			"Track startup analysis complete. TotalTracks={TotalTracks} CacheHits={CacheHits} Analyzed={Analyzed} ElapsedMs={ElapsedMs}",
+			_resolvedTracks.Count,
+			cacheHits,
+			analyzedCount,
+			stopwatch.ElapsedMilliseconds);
+	}
+
+	private bool TryGetFreshCachedEntry(string fingerprint, in ResolvedTrack resolvedTrack, out TrackAnalysisCacheEntry entry) {
+		if (
+			_analysisByFingerprint.TryGetValue(fingerprint, out TrackAnalysisCacheEntry existing) &&
+			existing.AnalysisVersion == CurrentAnalysisVersion &&
+			string.Equals(existing.FilePath, resolvedTrack.FilePath, StringComparison.OrdinalIgnoreCase) &&
+			existing.FileSize == resolvedTrack.FileSize &&
+			existing.LastWriteUtcTicks == resolvedTrack.LastWriteUtcTicks
+		) {
+			entry = existing;
+			return true;
+		}
+
+		entry = TrackAnalysisCacheEntry.Empty;
+		return false;
+	}
+
+	private void LoadAnalysisCache() {
+		if (!File.Exists(_analysisCachePath)) {
+			return;
+		}
+
+		TrackAnalysisCacheContainer? container;
+		try {
+			string json = File.ReadAllText(_analysisCachePath);
+			container = JsonSerializer.Deserialize<TrackAnalysisCacheContainer>(json);
+		} catch (Exception ex) {
+			PlayerLogger.Warning(ex, "Could not read analysis cache '{Path}'. Rebuilding cache.", _analysisCachePath);
+			_analysisByFingerprint.Clear();
+			return;
+		}
+		if (container is null) {
+			PlayerLogger.Warning("Could not deserialize analysis cache '{Path}'. Rebuilding cache.", _analysisCachePath);
+			_analysisByFingerprint.Clear();
+			return;
+		}
+
+		_analysisByFingerprint.Clear();
+		foreach (TrackAnalysisCacheEntry entry in container.Entries.Where(e => !string.IsNullOrEmpty(e.Fingerprint))) {
+			_analysisByFingerprint[entry.Fingerprint] = entry;
+		}
+	}
+
+	private void SaveAnalysisCache() {
+		TrackAnalysisCacheContainer container = new TrackAnalysisCacheContainer {
+			AnalysisVersion = CurrentAnalysisVersion,
+			Entries = _analysisByFingerprint.Values.OrderBy(e => e.Fingerprint, StringComparer.Ordinal).ToList()
+		};
+		string json = JsonSerializer.Serialize(container, new JsonSerializerOptions { WriteIndented = true });
+		File.WriteAllText(_analysisCachePath, json);
+	}
+
+	private static Dictionary<string, string> BuildFileNameLookup(string folderPath) {
+		return Directory
+			.GetFiles(folderPath)
+			.Where(path => !string.IsNullOrEmpty(Path.GetFileName(path)))
+			.ToDictionary(path => Path.GetFileName(path).ToLowerInvariant(), path => path, StringComparer.OrdinalIgnoreCase);
+	}
+
+	private void ApplyTrackSkip(long skipMs, string filePath, string fingerprint) {
+		if (skipMs <= 0) {
+			return;
+		}
+
+		DateTime deadline = DateTime.UtcNow.AddSeconds(2);
+		while (DateTime.UtcNow < deadline) {
+			if (_mediaPlayer.IsSeekable && _mediaPlayer.Length > 0) {
+				break;
+			}
+			Thread.Sleep(10);
+		}
+
+		if (!_mediaPlayer.IsSeekable || _mediaPlayer.Length <= 0) {
+			throw new InvalidOperationException($"Track '{filePath}' is not seekable for fingerprint '{fingerprint}'.");
+		}
+
+		long clampedSkipMs = Math.Min(skipMs, Math.Max(0, _mediaPlayer.Length - 1));
+		_mediaPlayer.SeekTo(TimeSpan.FromMilliseconds(clampedSkipMs));
+		PlayerLogger.Debug("Applied startup skip. Fingerprint={Fingerprint} SkipMs={SkipMs} File='{FilePath}'", fingerprint, clampedSkipMs, filePath);
+	}
+
 	private void LoadRegistry() {
 		string registryPath = Path.Combine(_folderPath, "fingerprints.json");
 		if (!File.Exists(registryPath)) {
-			PlayerLogger.Warning("fingerprints.json not found at '{Path}'. Song names will be unknown.", registryPath);
-			return;
+			throw new FileNotFoundException($"fingerprints.json not found at '{registryPath}'.", registryPath);
 		}
 		string json = File.ReadAllText(registryPath);
 		MergeRegistryFromJson(json, registryPath);
@@ -208,12 +391,91 @@ public sealed class MusicFolderPlayer : IDisposable {
 	private void MergeRegistryFromJson(string json, string source) {
 		Dictionary<string, FingerprintEntry>? entries = JsonSerializer.Deserialize<Dictionary<string, FingerprintEntry>>(json);
 		if (entries is null) {
-			PlayerLogger.Warning("fingerprints.json from {Source} could not be parsed (null result).", source);
-			return;
+			throw new InvalidOperationException($"fingerprints.json from '{source}' could not be parsed.");
 		}
 		foreach (KeyValuePair<string, FingerprintEntry> pair in entries) {
 			_registry[pair.Key] = pair.Value;
 		}
+
+		if (_registry.Count == 0) {
+			throw new InvalidOperationException($"fingerprints.json from '{source}' is empty.");
+		}
+	}
+}
+
+internal sealed class TrackAnalysisCacheContainer {
+	[JsonPropertyName("analysisVersion")]
+	public int AnalysisVersion { get; set; }
+
+	[JsonPropertyName("entries")]
+	public List<TrackAnalysisCacheEntry> Entries { get; set; } = [];
+}
+
+[StructLayout(LayoutKind.Auto)]
+internal readonly struct ResolvedTrack {
+	public ResolvedTrack(string filePath, long fileSize, long lastWriteUtcTicks) {
+		FilePath = filePath;
+		FileSize = fileSize;
+		LastWriteUtcTicks = lastWriteUtcTicks;
+	}
+
+	public string FilePath { get; }
+	public long FileSize { get; }
+	public long LastWriteUtcTicks { get; }
+}
+
+[StructLayout(LayoutKind.Auto)]
+internal readonly struct TrackAnalysisCacheEntry {
+	public static readonly TrackAnalysisCacheEntry Empty = new TrackAnalysisCacheEntry(string.Empty, 0, 0.0, 0, string.Empty, 0, 0);
+
+	public TrackAnalysisCacheEntry(
+		string fingerprint,
+		long skipMs,
+		double confidence,
+		int analysisVersion,
+		string filePath,
+		long fileSize,
+		long lastWriteUtcTicks) {
+		Fingerprint = fingerprint;
+		SkipMs = skipMs;
+		Confidence = confidence;
+		AnalysisVersion = analysisVersion;
+		FilePath = filePath;
+		FileSize = fileSize;
+		LastWriteUtcTicks = lastWriteUtcTicks;
+	}
+
+	[JsonPropertyName("fingerprint")]
+	public string Fingerprint { get; init; }
+
+	[JsonPropertyName("skipMs")]
+	public long SkipMs { get; init; }
+
+	[JsonPropertyName("confidence")]
+	public double Confidence { get; init; }
+
+	[JsonPropertyName("analysisVersion")]
+	public int AnalysisVersion { get; init; }
+
+	[JsonPropertyName("filePath")]
+	public string FilePath { get; init; }
+
+	[JsonPropertyName("fileSize")]
+	public long FileSize { get; init; }
+
+	[JsonPropertyName("lastWriteUtcTicks")]
+	public long LastWriteUtcTicks { get; init; }
+
+	public static TrackAnalysisCacheEntry Create(
+		string fingerprint,
+		long skipMs,
+		double confidence,
+		int analysisVersion,
+		string filePath,
+		long fileSize,
+		long lastWriteUtcTicks
+	) {
+		return new TrackAnalysisCacheEntry(fingerprint, skipMs, confidence, analysisVersion, filePath, fileSize, lastWriteUtcTicks);
 	}
 }
 

--- a/src/Cryogenic/Services/StartupTrackSilenceAnalyzer.cs
+++ b/src/Cryogenic/Services/StartupTrackSilenceAnalyzer.cs
@@ -56,10 +56,7 @@ internal sealed class StartupTrackSilenceAnalyzer {
 
 		Stopwatch stopwatch = Stopwatch.StartNew();
 		while (stopwatch.ElapsedMilliseconds < AnalysisTimeoutMs) {
-			if (accumulator.ShouldStop) {
-				break;
-			}
-			Thread.Sleep(10);
+			SpinWait.SpinUntil(() => accumulator.ShouldStop);
 		}
 		analysisPlayer.Stop();
 

--- a/src/Cryogenic/Services/StartupTrackSilenceAnalyzer.cs
+++ b/src/Cryogenic/Services/StartupTrackSilenceAnalyzer.cs
@@ -1,0 +1,163 @@
+﻿namespace Cryogenic.Services;
+
+using LibVLCSharp.Shared;
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+/// <summary>
+/// Analyzes leading audio content to compute a conservative skip offset for startup playback.
+/// </summary>
+internal sealed class StartupTrackSilenceAnalyzer {
+	private const uint AnalysisSampleRateHz = 44100;
+	private const uint AnalysisChannelCount = 2;
+	private const string AnalysisAudioFormat = "S16N";
+	private const int AnalysisWindowMs = 45000;
+	private const int AnalysisTimeoutMs = 15000;
+	private const double SilenceThresholdRms = 0.01;
+	private const double SustainWindowMs = 220.0;
+	private const double OnsetPreRollMs = 120.0;
+
+	private readonly LibVLC _libVlc;
+
+	public StartupTrackSilenceAnalyzer(LibVLC libVlc) {
+		_libVlc = libVlc;
+	}
+
+	/// <summary>
+	/// Computes a per-track skip offset in milliseconds from decoded audio content.
+	/// </summary>
+	public TrackSilenceAnalysisResult Analyze(string trackPath) {
+		using MediaPlayer analysisPlayer = new MediaPlayer(_libVlc);
+		AnalysisAccumulator accumulator = new AnalysisAccumulator(AnalysisWindowMs, SilenceThresholdRms, SustainWindowMs);
+
+		void PlayCallback(IntPtr data, IntPtr samples, uint count, long pts) {
+			if (count == 0U) {
+				return;
+			}
+			int frameCount = checked((int)count);
+			double rms = ComputeRms(samples, frameCount);
+			double chunkMs = frameCount * 1000.0 / AnalysisSampleRateHz;
+			accumulator.AddChunk(rms, chunkMs);
+		}
+
+		analysisPlayer.SetAudioFormat(AnalysisAudioFormat, AnalysisSampleRateHz, AnalysisChannelCount);
+		analysisPlayer.SetAudioCallbacks(PlayCallback, null, null, null, null);
+		using Media media = new Media(_libVlc, trackPath, FromType.FromPath);
+		analysisPlayer.Media = media;
+
+		bool started = analysisPlayer.Play();
+		if (!started) {
+			throw new InvalidOperationException($"Could not start analysis playback for '{trackPath}'.");
+		}
+
+		Stopwatch stopwatch = Stopwatch.StartNew();
+		while (stopwatch.ElapsedMilliseconds < AnalysisTimeoutMs) {
+			if (accumulator.ShouldStop) {
+				break;
+			}
+			Thread.Sleep(10);
+		}
+		analysisPlayer.Stop();
+
+		if (!accumulator.HasSamples) {
+			throw new InvalidOperationException($"No audio samples decoded while analyzing '{trackPath}'.");
+		}
+
+		long skipMs = 0;
+		double confidence = 0.0;
+		if (accumulator.HasOnset) {
+			double rawSkip = accumulator.OnsetMs - OnsetPreRollMs;
+			skipMs = Math.Max(0L, (long)Math.Round(rawSkip));
+			confidence = Math.Min(1.0, 0.7 + accumulator.SustainAtOnsetMs / 500.0);
+		}
+
+		return new TrackSilenceAnalysisResult(skipMs, confidence);
+	}
+
+	private static double ComputeRms(IntPtr samples, int frameCount) {
+		int totalSamples = checked(frameCount * (int)AnalysisChannelCount);
+		short[] rentedBuffer = ArrayPool<short>.Shared.Rent(totalSamples);
+		try {
+			Marshal.Copy(samples, rentedBuffer, 0, totalSamples);
+			double sumSquares = 0.0;
+			for (int frame = 0; frame < frameCount; frame++) {
+				int baseIndex = frame * (int)AnalysisChannelCount;
+				double mono = 0.0;
+				for (int channel = 0; channel < (int)AnalysisChannelCount; channel++) {
+					mono += rentedBuffer[baseIndex + channel] / 32768.0;
+				}
+				mono /= AnalysisChannelCount;
+				sumSquares += mono * mono;
+			}
+			return Math.Sqrt(sumSquares / frameCount);
+		} finally {
+			ArrayPool<short>.Shared.Return(rentedBuffer);
+		}
+	}
+
+	private sealed class AnalysisAccumulator {
+		private readonly Lock _lock = new Lock();
+		private readonly int _analysisWindowMs;
+		private readonly double _silenceThresholdRms;
+		private readonly double _sustainWindowMs;
+		private double _decodedMs;
+		private double _sustainMs;
+
+		public AnalysisAccumulator(int analysisWindowMs, double silenceThresholdRms, double sustainWindowMs) {
+			_analysisWindowMs = analysisWindowMs;
+			_silenceThresholdRms = silenceThresholdRms;
+			_sustainWindowMs = sustainWindowMs;
+		}
+
+		public bool HasSamples { get; private set; }
+		public bool HasOnset { get; private set; }
+		public double OnsetMs { get; private set; }
+		public double SustainAtOnsetMs { get; private set; }
+
+		public bool ShouldStop {
+			get {
+				lock (_lock) {
+					return HasOnset || _decodedMs >= _analysisWindowMs;
+				}
+			}
+		}
+
+		public void AddChunk(double rms, double chunkMs) {
+			lock (_lock) {
+				HasSamples = true;
+				if (rms >= _silenceThresholdRms) {
+					_sustainMs += chunkMs;
+				} else {
+					_sustainMs = 0.0;
+				}
+
+				double chunkEndMs = _decodedMs + chunkMs;
+				if (!HasOnset && _sustainMs >= _sustainWindowMs) {
+					HasOnset = true;
+					OnsetMs = Math.Max(0.0, chunkEndMs - _sustainMs);
+					SustainAtOnsetMs = _sustainMs;
+				}
+
+				_decodedMs = chunkEndMs;
+			}
+		}
+	}
+}
+
+/// <summary>
+/// Result of per-track silence analysis.
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+internal readonly struct TrackSilenceAnalysisResult {
+	public TrackSilenceAnalysisResult(long skipMs, double confidence) {
+		SkipMs = skipMs;
+		Confidence = confidence;
+	}
+
+	public long SkipMs { get; }
+	public double Confidence { get; }
+}


### PR DESCRIPTION
### Description of Changes

feat: CD music: Add per-track silence skip analysis and caching

Introduce automatic startup silence detection for replacement audio tracks using RMS analysis via LibVLCSharp. Cache skip offsets in track-analysis-cache.json for fast startup and cache invalidation on file changes. Refactor MusicFolderPlayer to catalog tracks, apply skip offsets on playback and loop, and improve error handling and file resolution. Analysis is parallelized for efficiency.

### Rationale behind Changes

Music is as dynamic as OPL FM or MT-32 music. Let's enjoy it without the silence.

### Suggested Testing Steps

Already tested with DUNE CD.
